### PR TITLE
V1.2.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,24 @@ When constructing up the iCal object, you can specify some settings. These also 
 
 > `autoReadableDate`: Boolean. If True, any loaded iCal data will automatically have human readable dates added to it.
 >> Defaults to `False` 
+
 >> Set value with `set_setting("autoReadableDate", value: bool)`
+
 >> Get value with `get_settings("autoReadableDate")`
 
 > `autoRemovePastEvents`: Boolean. If True, any loaded iCal data will automatically have expired events removed from it.
 >> Defaults to `False`
+
 >> Set value with `set_setting("autoRemovePastEvents", value: bool)`
+
 >> Get value with `get_settings("autoRemovePastEvents")`
 
 You can also load your iCal data into the constructor.
 > `rawiCal`: String. Raw iCal data, i.e. non-edited iCal data, otherwise an `ICALLoadError` error will be thrown.
 >> Defaults to `None` or `""`
+
 >> Set value with `load_iCal(iCal: str)` (see below)
+
 >> Get value with `get_raw_ical()`
 
 > `get_json()`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # iCal to JSON
 
-**Version 1.1.1**
+**Version 1.2.0**
+
+## Version 1.2.0 Updates
+
+- Removed iCalSettings. autoReadableDate and autoRemovePastEvents settings are now passed in the iCal constructor.
+- Removed iCalSettings errors.
+- Added setters and getters for settings
+- Added getter for raw iCal data
+- Fixed typo in error definitions
+- Updated example to reflect affected changes
 
 
 This class allows you to take iCal data and turn it into a JSON format. This version supports the following calendar events:
@@ -29,17 +38,25 @@ See example.py, or the documentation for help.
 
 # Documentation
 
-## iCal Settings
-
-When creating the converter object, you must pass an iCalSettings object as well.
-
-> `autoReadableDate` : BOOLEAN : If True, any loaded iCal data will automatically have human readable dates added to it.
->> Defaults to `False`
-
-> `autoRemovePastEvents` : BOOLEAN : If True, any loaded iCal data will automatically have expired events removed from it.
->> Defaults to `False`
-
 ## iCal
+
+When constructing up the iCal object, you can specify some settings. These also come with setter and getter methods.
+
+> `autoReadableDate`: Boolean. If True, any loaded iCal data will automatically have human readable dates added to it.
+>> Defaults to `False` 
+>> Set value with `set_setting("autoReadableDate", value: bool)`
+>> Get value with `get_settings("autoReadableDate")`
+
+> `autoRemovePastEvents`: Boolean. If True, any loaded iCal data will automatically have expired events removed from it.
+>> Defaults to `False`
+>> Set value with `set_setting("autoRemovePastEvents", value: bool)`
+>> Get value with `get_settings("autoRemovePastEvents")`
+
+You can also load your iCal data into the constructor.
+> `rawiCal`: String. Raw iCal data, i.e. non-edited iCal data, otherwise an `ICALLoadError` error will be thrown.
+>> Defaults to `None` or `""`
+>> Set value with `load_iCal(iCal: str)` (see below)
+>> Get value with `get_raw_ical()`
 
 > `get_json()`
 >> Returns the iCal data in its current state.
@@ -60,9 +77,6 @@ When creating the converter object, you must pass an iCalSettings object as well
 >> Saves the currently loaded data in a json file.
 
 ## Exceptions
-
-> `ICALInvalidSetting`
->> Raised if the defined setting is of the wrong data type.
 
 > `ICALNotLoaded`
 >> Raised if a method has been called that requires loaded iCal data, but no iCal data is loaded.

--- a/example.py
+++ b/example.py
@@ -3,7 +3,6 @@ from iCalToJson import iCal
 #Some raw data
 DATA = "BEGIN:VCALENDAR\nX-WR-CALNAME:Example\nX-WR-TIMEZONE:Europe/London\nPRODID:-//Example PRODID v2021//EN\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:This is the summary for event1\nLOCATION:This is the location for event1\nDTSTAMP:20210610T110000Z\nDTSTART:20210610T110000\nDTEND:20210610T180000\nCLASS:PUBLIC\nDESCRIPTION:This is the description for event1\nUID:00000000000000000000000000000001\nEND:VEVENT\nBEGIN:VEVENT\nSUMMARY:This is the summary for event2\nLOCATION:This is the location for event2\nDTSTAMP:20210710T110000Z\nDTSTART:20210710T110000\nDTEND:20210710T180000\nCLASS:PUBLIC\nDESCRIPTION:This is the description for event2\nUID:00000000000000000000000000000002\nEND:VEVENT"
 
-#The settings needed for our converter. Leaving these parameters empty will use defaults outlined in the README documentation
 
 #Create the converter using our settings
 converter = iCal(autoReadableDate=True)

--- a/example.py
+++ b/example.py
@@ -1,13 +1,12 @@
-from iCalToJson import iCal, iCalSettings
+from iCalToJson import iCal
 
 #Some raw data
 DATA = "BEGIN:VCALENDAR\nX-WR-CALNAME:Example\nX-WR-TIMEZONE:Europe/London\nPRODID:-//Example PRODID v2021//EN\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:This is the summary for event1\nLOCATION:This is the location for event1\nDTSTAMP:20210610T110000Z\nDTSTART:20210610T110000\nDTEND:20210610T180000\nCLASS:PUBLIC\nDESCRIPTION:This is the description for event1\nUID:00000000000000000000000000000001\nEND:VEVENT\nBEGIN:VEVENT\nSUMMARY:This is the summary for event2\nLOCATION:This is the location for event2\nDTSTAMP:20210710T110000Z\nDTSTART:20210710T110000\nDTEND:20210710T180000\nCLASS:PUBLIC\nDESCRIPTION:This is the description for event2\nUID:00000000000000000000000000000002\nEND:VEVENT"
 
 #The settings needed for our converter. Leaving these parameters empty will use defaults outlined in the README documentation
-settings = iCalSettings(autoReadableDate=True)
 
 #Create the converter using our settings
-converter = iCal(settings)
+converter = iCal(autoReadableDate=True)
 
 #Load our data into the converter.
 #This also formats the data into a dictionary and applies any auto settings, like autoReadableDate
@@ -18,11 +17,11 @@ converter = iCal(settings)
 #For data in a string
 converter.load_iCal(DATA)
 
+#Remove past events. This can be called no matter the value of the autoRemovePastEvents setting
+converter.remove_past_events()
+
 #We can get the dictionary by callng get_json()
 ourData = converter.get_json()
 
 #Save the data in a json file
 converter.save_JSON("exampleEvents.json")
-
-#Remove past events. This can be called no matter the value of the autoRemovePastEvents setting
-converter.remove_past_events()

--- a/iCalToJson.py
+++ b/iCalToJson.py
@@ -241,6 +241,24 @@ class iCal:
 
         return readableDT
 
+    def set_setting(self, setting: str, value: bool) -> None:
+        '''
+        Sets the setting to the new value
+        '''
+        if setting == "autoReadableDate":
+            self.__autoReadableDate = value
+        if setting == "autoRemovePastEvents":
+            self.__autoRemovePastEvents = value
+
+    def get_setting(self, setting: str) -> bool:
+        '''
+        Returns the value for the specified setting
+        '''
+        if setting == "autoReadableDate":
+            return self.__autoReadableDate
+        if setting == "autoRemovePastEvents":
+            return self.__autoRemovePastEvents
+
     def get_raw_ical(self) -> str:
         '''
         Returns the raw iCal data provided by the user

--- a/iCalToJson.py
+++ b/iCalToJson.py
@@ -3,6 +3,7 @@ import requests
 import datetime
 from typing import Union
 import os
+import urllib3
 
 DAY_SUFFIX = {
     "1":"st",
@@ -70,17 +71,13 @@ class ICalEditor(Base_ICAL_Error):
     def __init__(self, extra):
         super().__init__("Error trying to edit iCal data", extra)
 
-class ICalSettings(Base_ICAL_Error):
-    def __init__(self, extra):
-        super().__init__("Error trying to use iCal settings", extra)
-
 class ICALNotLoaded(ICalEditor):
-    def __init__(self, evidence=Union[str]):
+    def __init__(self, evidence:Union[str, None]):
         extra = "There is currently no iCal data loaded. Please load some data and try again"
         super().__init__(extra)
 
 class ICALLoadError(ICalLoading):
-    def __init__(self, evidence=Union[str]):
+    def __init__(self, evidence:Union[str, None]):
         extra = "The iCal you tried to load is not correct type or is in an invalid format. iCal data must be of type STRING and begin with 'BEGIN:VCALENDAR'"
         if evidence is not None:
             extra += f"[{type(evidence)}]"
@@ -89,7 +86,7 @@ class ICALLoadError(ICalLoading):
         super().__init__(extra)
 
 class ICALLoadErrorWP(ICalLoading):
-    def __init__(self, evidence=Union[requests.Response]):
+    def __init__(self, evidence:Union[requests.Response, None]):
         extra = "The iCal you tried to load is not correct type or is in an invalid format. iCal data must be of type STRING and begin with 'BEGIN:VCALENDAR'"
         if evidence is not None:
             extra += f"[{type(evidence)}]"
@@ -98,7 +95,7 @@ class ICALLoadErrorWP(ICalLoading):
         super().__init__(extra)
 
 class ICALInvalidURL(ICalLoading):
-    def __init__(self, evidence=Union[str]):
+    def __init__(self, evidence:Union[str, None]):
         extra = "The URL you passed did not exist or there was an issue connecting to it"
         if evidence is not None:
             extra += f"[{evidence}]"
@@ -106,51 +103,13 @@ class ICALInvalidURL(ICalLoading):
                 extra += f" [{evidence[:15]}]"
         super().__init__(extra)
 
-class ICALInvalidSetting(ICalSettings):
-    def __init__(self, evidence=Union[str], expectedType=Union[object], gotType=Union[object]):
-        extra = f"Setting {evidence} is not a valid setting type. [Expected: {expectedType}] [Got: {gotType}]"
-        super().__init__(extra)
-
-
-class iCalSettings:
-    def __init__(self, **settings):
-
-        '''
-        autoReadableDate : Automatically inserts a readable date format into the data
-        Calls convert_times
-
-        autoRemovePastEvents : Automatically removes any past events
-        Calls remove_past_events
-        '''
-
-        if "autoReadableDate" in settings:
-            if type(settings['autoReadableDate']) == bool:
-                self.__autoReadableDate = settings['autoReadableDate']
-            else:
-                raise ICALInvalidSetting(evidence="autoReadableDate", expectedType=bool, gotType=type(settings['autoReadableDate']))
-        else:
-            self.__autoReadableDate = False
-
-        if "autoRemovePastEvents" in settings:
-            if type(settings['autoRemovePastEvents']) == bool:
-                self.__autoRemovePastEvents = settings['autoRemovePastEvents']
-            else:
-                raise ICALInvalidSetting(evidence="autoRemovePastEvents", expectedType=bool, gotType=type(settings['autoRemovePastEvents']))
-        else:
-            self.__autoRemovePastEvents = False
-
-    def getAutoReadableDate(self) -> bool:
-        return self.__autoReadableDate
-
-    def getAutoRemovePastEvents(self) -> bool:
-        return self.__autoRemovePastEvents
 
 
 class iCal:
-    def __init__(self, settings: iCalSettings, rawiCal:str=""):
-        self.__settings = settings
+    def __init__(self, autoReadableDate: bool=False, autoRemovePastEvents: bool=False, rawiCal:str=""):
+        self.__autoReadableDate = autoReadableDate
+        self.__autoRemovePastEvents = autoRemovePastEvents
         self.__rawICAL = ""
-        self.__2dICAL = []
         self.__ICAL = {}
         if rawiCal != "":
             self.load_iCal(rawiCal)
@@ -161,9 +120,9 @@ class iCal:
         '''
         Assumes ICAL has already been converted to dict
         '''
-        if self.__settings.getAutoReadableDate():
+        if self.__autoReadableDate:
             self.convert_times()
-        if self.__settings.getAutoRemovePastEvents():
+        if self.__autoRemovePastEvents:
             self.remove_past_events()
 
     def __validate_iCal(self, iCal:str) -> bool:
@@ -230,7 +189,7 @@ class iCal:
 
         return objectDict
 
-    def __requestFromWebpage(self, url: str) -> Union[str]:
+    def __requestFromWebpage(self, url: str) -> Union[str, None]:
         '''
         Sends a request to the URL and returns the text response
         '''
@@ -282,6 +241,12 @@ class iCal:
 
         return readableDT
 
+    def get_raw_ical(self) -> str:
+        '''
+        Returns the raw iCal data provided by the user
+        '''
+        return self.__rawICAL
+
     def get_json(self) -> dict:
         '''
         Returns the iCal events as a json format (dict)
@@ -300,8 +265,8 @@ class iCal:
         '''
         if self.__validate_iCal(iCal):
             self.__rawICAL = iCal
-            self.__2dICAL = self.__object_string_to_2dlist(self.__rawICAL)
-            self.__ICAL = self.__object_list_to_dict(self.__2dICAL)
+            ICAL2d = self.__object_string_to_2dlist(self.__rawICAL)
+            self.__ICAL = self.__object_list_to_dict(ICAL2d)
             self.__auto_settings()
         else:
             raise ICALLoadError(evidence=iCal)


### PR DESCRIPTION
Version 1.2.0 Update includes the following changes:
- Removed iCalSettings. autoReadableDate and autoRemovePastEvents settings are now passed in the iCal constructor.
- Removed iCalSettings errors.
- Added setters and getters for settings
- Added getter for raw iCal data
- Fixed typo in error definitions
- Updated example to reflect affected changes